### PR TITLE
feat: add logs drawer and diff dialog upgrades

### DIFF
--- a/utils/diff.py
+++ b/utils/diff.py
@@ -1,0 +1,35 @@
+import difflib
+from typing import List, Tuple, Optional
+
+def side_by_side(a: str, b: str) -> Tuple[List[str], List[str], List[Optional[str]], List[Optional[str]]]:
+    """Return side-by-side diff data between strings ``a`` and ``b``.
+
+    Returns tuple of (left_lines, right_lines, left_styles, right_styles) where
+    styles list contains ``'del'`` for deletions and ``'add'`` for additions.
+    ``None`` indicates unchanged line.
+    """
+    left_lines: List[str] = []
+    right_lines: List[str] = []
+    left_styles: List[Optional[str]] = []
+    right_styles: List[Optional[str]] = []
+
+    for line in difflib.ndiff(a.splitlines(), b.splitlines()):
+        tag = line[:2]
+        text = line[2:]
+        if tag == ' ':  # unchanged
+            left_lines.append('  ' + text)
+            right_lines.append('  ' + text)
+            left_styles.append(None)
+            right_styles.append(None)
+        elif tag == '- ':  # deletion on left
+            left_lines.append('- ' + text)
+            right_lines.append('')
+            left_styles.append('del')
+            right_styles.append(None)
+        elif tag == '+ ':  # addition on right
+            left_lines.append('')
+            right_lines.append('+ ' + text)
+            left_styles.append(None)
+            right_styles.append('add')
+        # ignore '? ' lines produced by ndiff
+    return left_lines, right_lines, left_styles, right_styles


### PR DESCRIPTION
## Summary
- revamp chat logs into an animated drawer with copy and severity colors
- display model, temperature and token/sec badges for each response
- upgrade diff dialog with color-coded side-by-side diff and new actions

## Testing
- `python -m py_compile app.py utils/diff.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adde80af348329a0b2686716c5201a