### PR TITLE
Add admin maintenance chat page and streaming endpoint

### DIFF
--- a/MAINTENANCE_PAGE_PLAN_AGILE.md
+++ b/MAINTENANCE_PAGE_PLAN_AGILE.md
@@ -29,12 +29,12 @@
 **Goal:** Allow admins to access a maintenance page with a requirement-gathering chat.
 
 ### Tasks
-- [ ] Create `/maintenance` Next.js route guarded for admins only.
-- [ ] Embed existing chat component with a system prompt detailing full instructions:
+- [x] Create `/maintenance` Next.js route guarded for admins only.
+- [x] Embed existing chat component with a system prompt detailing full instructions:
 
     *"You are an AI development agent. When the CEO describes a feature, ask clarifying questions until requirements are actionable and reply `CONFIRMED`. After confirmation, draft an implementation plan and invoke a coding service (e.g., Codex) to implement the feature. Run `pytest` and `npm test`, commit to a non-`main` branch, push, and open a pull request."*
-- [ ] Display "Generate Plan" button, enabled only after the assistant replies `CONFIRMED`.
-- [ ] Add backend router `POST /api/maintenance/stream` for requirement collection.
+- [x] Display "Generate Plan" button, enabled only after the assistant replies `CONFIRMED`.
+- [x] Add backend router `POST /api/maintenance/stream` for requirement collection.
 
 ### Definition of Done
 - Admin-only page renders successfully.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ for p in [repo_root, "/", os.path.join(repo_root, "tools")]:
 	if p not in sys.path:
 		sys.path.append(p)
 
-from .routers import health, projects, conversations, messages, sqltools, chat
+from .routers import health, projects, conversations, messages, sqltools, chat, maintenance
 from .db import init_db, engine
 from .services.tgi_client import client as tgi
 
@@ -49,7 +49,8 @@ def create_app() -> FastAPI:
 	app.include_router(sqltools.router, prefix="/api")
 	from .routers import auth as auth_router
 
-	app.include_router(chat.router, prefix="/api")
+        app.include_router(chat.router, prefix="/api")
+        app.include_router(maintenance.router, prefix="/api")
 	app.include_router(auth_router.router, prefix="/api")
 	from .routers import admin as admin_router
 	app.include_router(admin_router.router, prefix="/api")

--- a/backend/app/routers/maintenance.py
+++ b/backend/app/routers/maintenance.py
@@ -1,0 +1,51 @@
+import json
+from typing import AsyncGenerator, List, Optional
+
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from ..config import settings
+from ..services.tgi_client import client as tgi, ollama_client
+
+router = APIRouter(prefix="/maintenance", tags=["maintenance"])
+
+class MaintenanceMessage(BaseModel):
+    role: str
+    content: str
+
+class MaintenanceStreamRequest(BaseModel):
+    messages: List[MaintenanceMessage]
+    temperature: Optional[float] = None
+    max_tokens: Optional[int] = None
+
+
+def _build_prompt(messages: List[MaintenanceMessage]) -> str:
+    parts: List[str] = []
+    for m in messages:
+        role = m.role if m.role in {"user", "assistant", "system"} else "user"
+        parts.append(f"<|{role}|>\n{m.content}")
+    parts.append("<|assistant|>")
+    return "\n".join(parts)
+
+
+@router.post("/stream")
+def stream_requirements(request: MaintenanceStreamRequest):
+    async def generator() -> AsyncGenerator[str, None]:
+        prompt = _build_prompt(request.messages)
+        temperature = request.temperature or settings.temperature
+        max_tokens = request.max_tokens or settings.max_tokens
+        backend = settings.model_backend
+        if backend == "ollama":
+            async for item in ollama_client.stream_generate(prompt, temperature, max_tokens, model=settings.default_model_id):
+                delta = item.get("token", {}).get("text", "")
+                if delta:
+                    yield f"event: delta\ndata: {json.dumps({'text': delta})}\n\n"
+        else:
+            async for item in tgi.stream_generate(prompt, temperature, max_tokens):
+                delta = item.get("token", {}).get("text", "")
+                if delta:
+                    yield f"event: delta\ndata: {json.dumps({'text': delta})}\n\n"
+        yield "event: done\ndata: {}\n\n"
+
+    return StreamingResponse(generator(), media_type="text/event-stream")

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -50,7 +50,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   const isLoginPage = pathname === "/login";
   
   // Check if current route requires admin access
-  const isAdminRoute = pathname.startsWith("/admin");
+  const isAdminRoute = pathname.startsWith("/admin") || pathname.startsWith("/maintenance");
 
   return (
     <html lang="en" suppressHydrationWarning>

--- a/frontend/app/maintenance/page.tsx
+++ b/frontend/app/maintenance/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import React, { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+interface Message {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+const SYSTEM_PROMPT = `You are an AI development agent. When the CEO describes a feature, ask clarifying questions until requirements are actionable and reply CONFIRMED. After confirmation, draft an implementation plan and invoke a coding service (e.g., Codex) to implement the feature. Run pytest and npm test, commit to a non-main branch, push, and open a pull request.`;
+
+export default function MaintenancePage() {
+  const [messages, setMessages] = useState<Message[]>([{ role: "system", content: SYSTEM_PROMPT }]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const updated = [...messages, { role: "user", content: input }];
+    setMessages(updated);
+    setInput("");
+    setLoading(true);
+
+    const response = await fetch("/api/maintenance/stream", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: updated }),
+    });
+
+    if (!response.body) {
+      setLoading(false);
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let assistant = "";
+    const assistantIndex = updated.length;
+    setMessages((msgs) => [...msgs, { role: "assistant", content: "" }]);
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const chunk = decoder.decode(value, { stream: true });
+      const parts = chunk.split("\n\n");
+      for (const part of parts) {
+        if (!part.trim()) continue;
+        const lines = part.split("\n");
+        const eventLine = lines.find((l) => l.startsWith("event:"));
+        const dataLine = lines.find((l) => l.startsWith("data:"));
+        if (!dataLine) continue;
+        const event = eventLine ? eventLine.replace("event:", "").trim() : "";
+        const data = JSON.parse(dataLine.replace("data:", "").trim());
+        if (event === "delta" && typeof data.text === "string") {
+          assistant += data.text;
+          setMessages((msgs) => {
+            const next = [...msgs];
+            next[assistantIndex] = { role: "assistant", content: assistant };
+            return next;
+          });
+        }
+      }
+    }
+
+    setLoading(false);
+    if (assistant.includes("CONFIRMED")) {
+      setConfirmed(true);
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-4 space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Maintenance</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <ScrollArea className="h-80 border rounded p-4">
+            {messages
+              .filter((m) => m.role !== "system")
+              .map((m, idx) => (
+                <div key={idx} className="mb-2">
+                  <div className="font-semibold text-sm capitalize">{m.role}</div>
+                  <div className="whitespace-pre-wrap text-sm">{m.content}</div>
+                </div>
+              ))}
+          </ScrollArea>
+          <div className="flex flex-col gap-2">
+            <Textarea
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              disabled={loading}
+              placeholder="Describe the feature..."
+            />
+            <div className="flex gap-2">
+              <Button onClick={sendMessage} disabled={loading || !input.trim()}>
+                Send
+              </Button>
+              <Button variant="secondary" disabled={!confirmed}>
+                Generate Plan
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/maintenance` admin-only page with requirement-gathering chat and Generate Plan control
- stream maintenance chat via new `/api/maintenance/stream` backend endpoint
- mark Sprint 1 maintenance page tasks as completed in agile plan

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68b4874590a08329889826183e590fce